### PR TITLE
Img fixes

### DIFF
--- a/scripts/generate_img.sh
+++ b/scripts/generate_img.sh
@@ -27,7 +27,7 @@ TEMPDIR=$(mktemp -d)
 ###
 imagename="beaglebone-getting-started-$(git log -1 --date=short --pretty=format:%cd)"
 image_size_mb="40"
-image_format="iso"
+image_format="fat"
 ###
 
 check_root () {

--- a/scripts/generate_img.sh
+++ b/scripts/generate_img.sh
@@ -26,7 +26,7 @@ TEMPDIR=$(mktemp -d)
 
 ###
 imagename="beaglebone-getting-started-$(git log -1 --date=short --pretty=format:%cd)"
-image_size_mb="40"
+image_size_mb="18"
 image_format="fat"
 ###
 


### PR DESCRIPTION
We are still shipping *.img files, haven't tested MacOSX in awhile with the *.iso file.

With the board file removal, this can now be 18Mb

```
Space Used...
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/loop0p1   17M   14M  3.7M  79% /tmp/tmp.6qDVuhOHfS/disk
```